### PR TITLE
Feat/title bar label

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,12 +38,12 @@
                         {
                             "regex": ".*/web/.*",
                             "color": "#c0d8e3",
-                            "label": "web"
+                            "label": "WEB"
                         },
                         {
                             "regex": ".*/mobile/.*",
                             "color": "#e18a7a",
-                            "label": "mobile"
+                            "label": "MOBILE"
                         }
                     ],
                     "description": "list of mappings from path to color"
@@ -61,7 +61,7 @@
                 "colorTabs.titleLabel": {
                     "type": "boolean",
                     "default": false,
-                    "description": "label the background using the provided regex label "
+                    "description": "append label to the title bar using the provided regex label "
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -37,11 +37,13 @@
                     "default": [
                         {
                             "regex": ".*/web/.*",
-                            "color": "#c0d8e3"
+                            "color": "#c0d8e3",
+                            "label": "web"
                         },
                         {
                             "regex": ".*/mobile/.*",
-                            "color": "#e18a7a"
+                            "color": "#e18a7a",
+                            "label": "mobile"
                         }
                     ],
                     "description": "list of mappings from path to color"
@@ -55,6 +57,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "color title bar background if regex match found"
+                },
+                "colorTabs.titleLabel": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "label the background using the provided regex label "
                 }
             }
         }

--- a/src/changeLabel.ts
+++ b/src/changeLabel.ts
@@ -1,0 +1,29 @@
+import * as vscode from 'vscode';
+import getSettings from './getSettings';
+
+const addOrReplaceLabel = (label, originalString): string => {
+    const regex = new RegExp('(~\[.*\]~)(.*)', 'g');
+    const hasLabel = regex.test(originalString);
+
+    if (hasLabel) {
+        originalString.replace(regex, `~[${label}]~\$\{\separator}$3`);
+    } else {
+        return `~[${label}]~\$\{\separator}${originalString}`;
+    }
+}
+
+export default async (label?: string) => {
+    const settings = vscode.workspace.getConfiguration('window');
+    const currentTitleSetting = settings.get('title') || {};
+    const extensionSettings = getSettings();
+
+    const shouldAppendLabel = extensionSettings.titleLabel;
+
+    if (shouldAppendLabel && label) {
+        const newTitle = addOrReplaceLabel(label, currentTitleSetting);
+        console.log("WOOHOOO TITLE", newTitle)
+        settings.update('title', newTitle, vscode.ConfigurationTarget.Workspace);
+    } else {
+        settings.update('title', {}, vscode.ConfigurationTarget.Workspace);
+    }
+}

--- a/src/changeLabel.ts
+++ b/src/changeLabel.ts
@@ -1,29 +1,33 @@
 import * as vscode from 'vscode';
 import getSettings from './getSettings';
 
-const addOrReplaceLabel = (label, originalString): string => {
-    const regex = new RegExp('(~\[.*\]~)(.*)', 'g');
+const addOrReplaceLabel = (label: string, originalString: string): string => {
+    const regex = new RegExp(/(~\[.*\]~)(.*)/, 'g');
     const hasLabel = regex.test(originalString);
 
+    
     if (hasLabel) {
-        originalString.replace(regex, `~[${label}]~\$\{\separator}$3`);
+        return originalString.replace(regex, `~[${label}]~\$\{\separator}$2`);
     } else {
         return `~[${label}]~\$\{\separator}${originalString}`;
     }
 }
 
-export default async (label?: string) => {
-    const settings = vscode.workspace.getConfiguration('window');
-    const currentTitleSetting = settings.get('title') || {};
+const isFeatureEnabled = (): boolean => {
     const extensionSettings = getSettings();
-
     const shouldAppendLabel = extensionSettings.titleLabel;
+    return !!shouldAppendLabel;
+} 
 
-    if (shouldAppendLabel && label) {
+export default async (label?: string) => {
+    if (!isFeatureEnabled()) return;
+    
+    const settings = vscode.workspace.getConfiguration('window');
+    const currentTitleSetting = settings.get<string>('title') || '';
+    if (label) {
         const newTitle = addOrReplaceLabel(label, currentTitleSetting);
-        console.log("WOOHOOO TITLE", newTitle)
         settings.update('title', newTitle, vscode.ConfigurationTarget.Workspace);
     } else {
-        settings.update('title', {}, vscode.ConfigurationTarget.Workspace);
+        settings.update('title', undefined, vscode.ConfigurationTarget.Workspace);
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,8 @@
 'use strict';
 import * as vscode from 'vscode';
-import getColorForPath from './getColor';
+import getMapping from './getMapping';
 import changeColors from './changeColors';
+import changeLabel from './changeLabel';
 
 export function activate(context: vscode.ExtensionContext) {
     
@@ -10,9 +11,12 @@ export function activate(context: vscode.ExtensionContext) {
         if (!e) return null;
         const currentlyOpenTabfilePath = e.document.fileName;
         
-        const color = getColorForPath(currentlyOpenTabfilePath);
+        const mapping = getMapping(currentlyOpenTabfilePath);
         try {
-            await changeColors(color);
+            await Promise.all([
+                changeColors(mapping && mapping.color),
+                changeLabel(mapping && mapping.label)
+            ]);
         } catch (error) {
             console.log("ERROR", error);
         }

--- a/src/getMapping.ts
+++ b/src/getMapping.ts
@@ -1,10 +1,10 @@
-import getSettings from './getSettings'
+import getSettings, {ColorRegex} from './getSettings';
 
-export default (path: string) => {
+export default (path: string): ColorRegex | undefined => {
     const config = getSettings().config;
     if (!config) return undefined;
     
     const map = config.find(mapping => new RegExp(mapping.regex, 'g').test(path));
     if (!map) return undefined;
-    return map.color;
+    return map;
 }

--- a/src/getSettings.ts
+++ b/src/getSettings.ts
@@ -1,14 +1,16 @@
 import * as vscode from 'vscode';
 
-type ColorRegex = {
+export type ColorRegex = {
     regex: string;
     color: string;
-}
+    label?: string;
+};
 
 type AllSettings = {
     config?: ColorRegex[];
     tabBorder?: boolean;
     titleBackground?: boolean;
+    titleLabel?: boolean;
 }
 
-export default () => vscode.workspace.getConfiguration('colorTabs') as unknown as AllSettings
+export default () => vscode.workspace.getConfiguration('colorTabs') as AllSettings;

--- a/tslint.json
+++ b/tslint.json
@@ -3,7 +3,7 @@
 		"no-string-throw": true,
 		"no-unused-expression": true,
 		"no-duplicate-variable": true,
-		"curly": true,
+		"curly": false,
 		"class-name": true,
 		"semicolon": [
 			true,


### PR DESCRIPTION
For feature request #3 

the config now accepts 3 params:  `regex, color, label`
If `label` is provided and the boolean configuration of `titleLabel` is `true`, we append to the prefix of the titlebar your label like so `~[<your_label>]~`

The reason we need the `~[ ]~` is for regex replacement, so I needed something unique :(


<img width="426" alt="screen shot 2019-02-26 at 20 01 58" src="https://user-images.githubusercontent.com/2146999/53439014-65466000-3a01-11e9-9cbd-1b0b227c8466.png">
<img width="313" alt="screen shot 2019-02-26 at 20 01 43" src="https://user-images.githubusercontent.com/2146999/53439021-67a8ba00-3a01-11e9-8b05-c8d6843adc17.png">
