### PR TITLE
More components coloring options

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,16 @@
                     "default": false,
                     "description": "color title bar background if regex match found"
                 },
+                "colorTabs.activityBarBackground": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "color activity bar background if regex match found"
+                },
+                "colorTabs.statusBarBackground": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "color status bar background if regex match found"
+                },
                 "colorTabs.titleLabel": {
                     "type": "boolean",
                     "default": false,

--- a/src/changeColors.ts
+++ b/src/changeColors.ts
@@ -6,12 +6,17 @@ type ColorCustomization = { [key: string]: string | undefined };
 export default async (color?: string) => {
     const settings = vscode.workspace.getConfiguration('workbench');
     const currentColorCustomization: ColorCustomization = settings.get('colorCustomizations') || {};
-    const extensionSettings = getSettings();
+    const {
+        tabBorder,
+        titleBackground,
+        activityBarBackground,
+        statusBarBackground,
+    } = getSettings()
 
-    const tabBarBorderColor = (extensionSettings.tabBorder !== false) ? color : undefined;
-    const titleBarBackgroundColor = extensionSettings.titleBackground ? color : undefined;
-    const activityBarBackgroundColor = extensionSettings.activityBarBackground ? color : undefined;
-    const statusBarBackgroundColor = extensionSettings.statusBarBackground ? color : undefined;
+    const tabBarBorderColor = (tabBorder !== false) ? color : undefined;
+    const titleBarBackgroundColor = titleBackground ? color : undefined;
+    const activityBarBackgroundColor = activityBarBackground ? color : undefined;
+    const statusBarBackgroundColor = statusBarBackground ? color : undefined;
 
     let colorCustomization: ColorCustomization = {
         ...currentColorCustomization,

--- a/src/changeColors.ts
+++ b/src/changeColors.ts
@@ -10,8 +10,16 @@ export default async (color?: string) => {
 
     const tabBarBorderColor = (extensionSettings.tabBorder !== false) ? color : undefined;
     const titleBarBackgroundColor = extensionSettings.titleBackground ? color : undefined;
+    const activityBarBackgroundColor = extensionSettings.activityBarBackground ? color : undefined;
+    const statusBarBackgroundColor = extensionSettings.statusBarBackground ? color : undefined;
 
-    let colorCustomization: ColorCustomization = { ...currentColorCustomization, 'tab.activeBorder': tabBarBorderColor, 'titleBar.activeBackground': titleBarBackgroundColor };
+    let colorCustomization: ColorCustomization = {
+        ...currentColorCustomization,
+        'tab.activeBorder': tabBarBorderColor,
+        'titleBar.activeBackground': titleBarBackgroundColor,
+        'activityBar.background': activityBarBackgroundColor,
+        'statusBar.background': statusBarBackgroundColor,
+    };
 
     settings.update('colorCustomizations', colorCustomization, vscode.ConfigurationTarget.Workspace);
 }

--- a/src/getSettings.ts
+++ b/src/getSettings.ts
@@ -10,6 +10,8 @@ type AllSettings = {
     config?: ColorRegex[];
     tabBorder?: boolean;
     titleBackground?: boolean;
+    activityBarBackground?: boolean;
+    statusBarBackground?: boolean;
     titleLabel?: boolean;
 }
 


### PR DESCRIPTION
This PR (closes #9) adds the ability to change the color of both the activity and status bar.
It uses the same single color that's being set in the extensions' settings.

I didn't add the ability to change the sidebar color because it's a bit more complexed of a component than the rest, having selected states for some nested items (e.g. headers and current selected file in the explorer) and multiple font colors so it doesn't look as nice when only changing 1 color.

I also made a minor code style refactor in `changeColors.ts` - destructuring the settings object since it became pretty long, I added it in a separate commit so it's easier to review and in case you prefer to revert that change.

One more necessary change that's not currently included in the PR but I can add if you want is the relevant changes to the readme, I wasn't sure if you want to handle that or not.