### PR TITLE
Add option to color tab background

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         },
         "colorTabs.tabBackground": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "color tab background if regex match found"
         },
         "colorTabs.titleBackground": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,11 @@
           "default": true,
           "description": "color tab border if regex match found"
         },
+        "colorTabs.tabBackground": {
+          "type": "boolean",
+          "default": true,
+          "description": "color tab background if regex match found"
+        },
         "colorTabs.titleBackground": {
           "type": "boolean",
           "default": false,

--- a/src/changeColors.ts
+++ b/src/changeColors.ts
@@ -20,6 +20,7 @@ export default async (color?: string) => {
     settings.get(COLOR_CUSTOMIZATIONS) || {};
   const {
     tabBorder,
+    tabBackground,
     titleBackground,
     activityBarBackground,
     statusBarBackground,
@@ -36,6 +37,7 @@ export default async (color?: string) => {
   const colorCustomization: ColorCustomization = {
     ...currentColorCustomization,
     ...(tabBorder ? { "tab.activeBorder": tabBarBorderColor } : {}),
+    ...(tabBackground ? { "tab.activeBackground": tabBarBorderColor } : {}),
     ...(titleBackground
       ? { "titleBar.activeBackground": titleBarBackgroundColor }
       : {}),

--- a/src/getSettings.ts
+++ b/src/getSettings.ts
@@ -9,6 +9,7 @@ export type ColorRegex = {
 type AllSettings = {
     config?: ColorRegex[];
     tabBorder?: boolean;
+    tabBackground?: boolean;
     ignoreCase?: boolean;
     titleBackground?: boolean;
     activityBarBackground?: boolean;


### PR DESCRIPTION
Hi 👋, 
I love this extension, but sometimes it's hard to notice the tab border color (especially when there's a horizontal scrollbar).

This PR introduces an additional option to set the background color of the active tab so that it would be more visible.